### PR TITLE
Revisión de enlaces muertos

### DIFF
--- a/extras/docs/inves/info.txt
+++ b/extras/docs/inves/info.txt
@@ -1,2 +1,2 @@
-http://www.zxprojects.com/index.php/the-fix-a-spectrum-blog/29-the-oddities-of-the-inves-spectrum
-http://zonadepruebas.org/backup/modules/newbb/viewtopic.php?topic_id=2442&forum=2&start=8
+https://web.archive.org/web/20161017211416/http://www.zxprojects.com:80/index.php/the-fix-a-spectrum-blog/29-the-oddities-of-the-inves-spectrum
+http://zonadepruebas.org/backup/modules/newbb/viewtopic.php?topic_id=2442&forum=2&start=8 # Se ha perdido


### PR DESCRIPTION
Los enlaces ya no están disponibles.
En archive.org sólo he encontrado el primero.
El segundo presumiblemente se ha perdido (aunque no da un 404, da una página en blanco).